### PR TITLE
Ensure that any bodies created in `GetBody` are cleaned up

### DIFF
--- a/gensupport/media.go
+++ b/gensupport/media.go
@@ -290,6 +290,7 @@ func (mi *MediaInfo) UploadRequest(reqHeaders http.Header, body io.Reader) (newB
 		fb := readerFunc(body)
 		fm := readerFunc(media)
 		combined, ctype := CombineBodyMedia(body, "application/json", media, mi.mType)
+		toCleanup := []io.Closer{combined}
 		if fb != nil && fm != nil {
 			getBody = func() (io.ReadCloser, error) {
 				rb := ioutil.NopCloser(fb())
@@ -299,10 +300,15 @@ func (mi *MediaInfo) UploadRequest(reqHeaders http.Header, body io.Reader) (newB
 					mimeBoundary = params["boundary"]
 				}
 				r, _ := combineBodyMedia(rb, "application/json", rm, mi.mType, mimeBoundary)
+				toCleanup = append(toCleanup, r)
 				return r, nil
 			}
 		}
-		cleanup = func() { combined.Close() }
+		cleanup = func() {
+			for _, closer := range toCleanup {
+				_ = closer.Close()
+			}
+		}
 		reqHeaders.Set("Content-Type", ctype)
 		body = combined
 	}


### PR DESCRIPTION
This PR fixes issues brought up in:

https://github.com/googleapis/google-cloud-go/issues/1651
https://github.com/googleapis/google-cloud-go/issues/1380

As best I understand it, the goroutines will leak when `GetBody` is called and the resulting body is not closed.

This PR modifies `UploadRequest` to add any request bodies created by `GetBody` to the be cleaned up by the `cleanup` function that is returned.  Previously, only the main request would be cleaned up but not any of those returned by `GetBody`.

I've verified that this fixes the issue in our environment.

@DataDog/burrito 
@DataDog/cloud-integrations 